### PR TITLE
supervisord config improperly monitors rsyslog and bc-server

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -5,17 +5,19 @@ nodaemon=true
 command=/bin/bash -c "source /etc/apache2/envvars && exec /usr/sbin/apache2 -DFOREGROUND"
 
 [program:rsyslog]
-command=service rsyslog start
+command=/usr/sbin/rsyslogd -n
 autostart=true
 autorestart=true
 startretries=3
+redirect_stderr=true
 
 [program:bc]
 environment=LD_LIBRARY_PATH=/usr/lib/bluecherry
-command=/usr/sbin/bc-server -u bluecherry -g bluecherry
+command=/usr/sbin/bc-server -s -u bluecherry -g bluecherry
 autostart=true
 autorestart=true
 startretries=3
 
 [program:permissions]
 command=chown bluecherry:bluecherry /recordings
+autorestart=false


### PR DESCRIPTION
This PR fixes supervisor.conf to make bc-server (bluecherry) run NOT daemonized, and to make rsyslog also run not daemonized, so that supervisord can actually manage them as intented. 

Without this PR, supervisord thinks that rsyslog and bc-server have exited and it keeps trying to restart them (until the restart limit is reached). Then, once the retries limit is exceeded, supervisord is technically no longer monitoring the processes, which defeats the whole purpose of using supervisord.

For the future, I recommend that we abandon supervisord entirely, and instead use systemd to manage the processes. Systemd is baked into almost every linux distro by default now, and it arguably has better overall features and capabilities compared to supervisord.