### PR TITLE
Make default recordings dir writable also for webserver

### DIFF
--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -42,6 +42,7 @@ echo "> Writing /etc/bluecherry.conf"
 
 echo "> chown bluecherry:bluecherry /var/lib/bluecherry/recordings"
 chown bluecherry:bluecherry /var/lib/bluecherry/recordings
+chmod ug+rwx /var/lib/bluecherry/recordings
 
 
 # The bluecherry container's Dockerfile sets rsyslog to route the bluecherry


### PR DESCRIPTION
Issue https://github.com/bluecherrydvr/bluecherry-apps/issues/620
arises because the dir exists, is owned by bluecherry:bluecherry, but is
by default writable only by owning user, but not the owning group.

Fix this here in docker setup code.
bluecherry-apps code will be amended to handle this, too.

```
root@df79d5606903:~# sudo -u www-data php -r "echo is_writable('/var/lib/bluecherry/recordings') ? 'writable' : 'not writable';"; echo
not writable
root@df79d5606903:~# sudo -u www-data touch /var/lib/bluecherry/recordings/www-data.was.here
touch: cannot touch '/var/lib/bluecherry/recordings/www-data.was.here': Permission denied
root@df79d5606903:~# id
uid=0(root) gid=0(root) groups=0(root)
root@df79d5606903:~# id www-data
uid=33(www-data) gid=33(www-data) groups=33(www-data),4(adm),20(dialout),29(audio),44(video),999(bluecherry)
root@df79d5606903:~# ls -l /var/lib/bluecherry/recordings -d
drwxr-xr-x 2 bluecherry bluecherry 4096 Nov 24 00:36 /var/lib/bluecherry/recordings
root@df79d5606903:~# chmod g+w /var/lib/bluecherry/recordings
root@df79d5606903:~# ls -l /var/lib/bluecherry/recordings -d
drwxrwxr-x 2 bluecherry bluecherry 4096 Nov 24 00:36 /var/lib/bluecherry/recordings
root@df79d5606903:~# sudo -u www-data touch /var/lib/bluecherry/recordings/www-data.was.here
root@df79d5606903:~# sudo -u www-data php -r "echo is_writable('/var/lib/bluecherry/recordings') ? 'writable' : 'not writable';"; echo
writable
```