### PR TITLE
install.sh: .env in workingpath

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -124,7 +124,7 @@ BLUECHERRY_USERHOST=%
 BLUECHERRY_GROUP_ID=1000
 BLUECHERRY_USER_ID=1000
 
-" > bluecherry-docker/.env
+" > "$workingpath"/bluecherry-docker/.env
 }
 
 


### PR DESCRIPTION
should usually not make any difference, but let's keep it consistent